### PR TITLE
Don't manually specify builds to skip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,4 @@ source = [
 ]
 
 [tool.cibuildwheel]
-skip = ["cp38-*", "cp39-*"]
 free-threaded-support = true


### PR DESCRIPTION
https://cibuildwheel.pypa.io/en/stable/options/#requires-python should take care of it.